### PR TITLE
Set module to es6 to avoid angular warning

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "es6",
         "target": "es6",
         "noImplicitAny": false,
         "sourceMap": false,


### PR DESCRIPTION
> It is recommended that you avoid depending on CommonJS modules in your Angular applications. Depending on CommonJS modules can prevent bundlers and minifiers from optimizing your application, which results in larger bundle sizes. Instead, it is recommended that you use ECMAScript modules in your entire application.
(from [Configuring CommonJS dependencies](https://angular.io/guide/build#configuring-commonjs-dependencies)) 