### PR TITLE
Add coordinates to address

### DIFF
--- a/src/interfaces/address.ts
+++ b/src/interfaces/address.ts
@@ -52,6 +52,16 @@ export interface Address extends ShopifyObject {
     last_name?: string;
 
     /**
+     * The latitude of the address.
+     */
+    latitude?: string;
+
+    /**
+     * The longitude of the address.
+     */
+    longitude?: string;
+
+    /**
      * The name.
      */
     name?: string;

--- a/src/interfaces/address.ts
+++ b/src/interfaces/address.ts
@@ -54,12 +54,12 @@ export interface Address extends ShopifyObject {
     /**
      * The latitude of the address.
      */
-    latitude?: string;
+    latitude?: number;
 
     /**
      * The longitude of the address.
      */
-    longitude?: string;
+    longitude?: number;
 
     /**
      * The name.


### PR DESCRIPTION
For the shipping_address for example https://shopify.dev/docs/admin-api/rest/reference/orders/order#shipping-address-property-2021-04