### PR TITLE
Fetch metafields for an order

### DIFF
--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -10,6 +10,7 @@ export * from "./discounts";
 export * from "./gift_cards";
 export * from "./inventory_items";
 export * from "./inventory_levels";
+export * from "./metafields";
 export * from "./orders";
 export * from "./pages";
 export * from "./price_rule_discounts";

--- a/src/options/metafields.ts
+++ b/src/options/metafields.ts
@@ -1,0 +1,13 @@
+import { DateOptions, FieldOptions, ListOptions } from "./base";
+
+export interface MetafieldListOptions extends FieldOptions, DateOptions, ListOptions {
+    /**
+     * Shows metafields with given namespace
+     */
+    namespace?: string;
+
+    /**
+     * The type of the value of the listed metafields
+     */
+    value_type?: "string" | "integer";
+}

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -1,6 +1,6 @@
 import * as Options from '../options';
 import { BaseService } from '../infrastructure';
-import { Order, OrderCreate,Transaction } from '../interfaces';
+import { MetaField, Order, OrderCreate, Transaction } from '../interfaces';
 
 export class Orders extends BaseService {
     constructor(shopDomain: string, accessToken: string) {
@@ -90,6 +90,15 @@ export class Orders extends BaseService {
      */
     public cancel(id: number, options?: Options.OrderCancelOptions) {
         return this.createRequest<Order>("POST", `${id}/cancel.json`, 'order', options);
+    }
+
+    /**
+     * Gets a list of up to 250 metafields from the given order.
+     * @param id The order's id.
+     * @param options Options for filtering the results.
+     */
+    public metafields(id: number, options?: Options.MetafieldListOptions) {
+        return this.createRequest<Partial<MetaField>[]>("GET", `${id}/metafields.json`, 'metafields', options);
     }
 }
 


### PR DESCRIPTION
This is not tested. Please test it before merging!
I can't test it because I get an error during `yarn install`.

<details>
  <summary>The error if you are interested</summary>
  
  ```javascript
➤ YN0000: ┌ Resolution step
➤ YN0061: │ natives@npm:1.1.6 is deprecated: This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x.
➤ YN0061: │ tslint@npm:6.1.3 is deprecated: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
➤ YN0002: │ alsatian@npm:3.2.1 doesn't provide typescript (pfb597), requested by ts-node
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 2s 425ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ yargs@npm:14.2.3 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yargs@npm:16.2.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yn@npm:3.1.1 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yoga-layout-prebuilt@npm:1.10.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ typescript@npm:4.3.2 can't be found in the cache and will be fetched from the remote registry
➤ YN0066: │ typescript@patch:typescript@npm%3A4.3.2#builtin<compat/typescript>::version=4.3.2&hash=a45b0e: Cannot apply hunk #2 (set enableInlineHunks for details)
➤ YN0000: └ Completed in 3s 451ms
➤ YN0000: Failed with errors in 5s 882ms

  ```
</details>

I took the information about the endpoint from here https://shopify.dev/docs/admin-api/rest/reference/metafield